### PR TITLE
uavcan: use legacy pyuavcan package

### DIFF
--- a/modules/uavcan/canard_dsdlc/canard_dsdlc.py
+++ b/modules/uavcan/canard_dsdlc/canard_dsdlc.py
@@ -1,4 +1,4 @@
-import uavcan.dsdl
+import pyuavcan_v0.dsdl
 import argparse
 import os
 import em

--- a/modules/uavcan/canard_dsdlc/canard_dsdlc_helpers.py
+++ b/modules/uavcan/canard_dsdlc/canard_dsdlc_helpers.py
@@ -1,5 +1,5 @@
 import os
-import uavcan
+import pyuavcan_v0 as uavcan
 import errno
 import em
 import math


### PR DESCRIPTION
The old pyuavcan package required here has been renamed from what I can see.

This is against a new `hereflow` branch.