### PR TITLE
can_autobaud: Don't use baudrate from boot msg

### DIFF
--- a/modules/can_autobaud/can_autobaud.c
+++ b/modules/can_autobaud/can_autobaud.c
@@ -64,12 +64,18 @@ RUN_AFTER(CAN_INIT) {
 #endif
 
 #ifdef MODULE_BOOT_MSG_ENABLED
-    bool boot_msg_valid = get_boot_msg_valid();
+    // This is disabled because we have seen deployed bootloaders setting wrong baudrates
+    // if the timing is just right, e.g. around 1 to 1.5s after boot.
+    //
+    // Disabling this means that at worst we auto-baud again, or we just use the parameter
+    // in most cases anyway.
+    //
+    //bool boot_msg_valid = get_boot_msg_valid();
 
-    if (boot_msg_valid && is_baudrate_valid(boot_msg.canbus_info.baudrate)) {
-        canbus_baud = boot_msg.canbus_info.baudrate;
-        canbus_autobaud_enable = false;
-    }
+    //if (boot_msg_valid && is_baudrate_valid(boot_msg.canbus_info.baudrate)) {
+    //    canbus_baud = boot_msg.canbus_info.baudrate;
+    //    canbus_autobaud_enable = false;
+    //}
 #endif
 
     for (uint8_t i=0; i<LEN(valid_baudrates); i++) {


### PR DESCRIPTION
Presumably, the deployed bootloaders have the bug where baudrate transmitted in the boot msg is not correct.

For Pixhawk 6X the timing is just right somehow to get it stuck at baudrate 500000 instead of 1000000.

Disabling reading from boot msg seems fixes this.

The correct fix would probably be in the bootloader but it's not very realistic to update the bootloaders in the wild.

This is against a new `hereflow` branch.